### PR TITLE
Remove unused server test script

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,6 @@
     "dev": "concurrently \"tsc -w\" \"nodemon dist/server.js\"",
     "build": "tsc",
     "start": "node dist/server.js",
-    "test": "jest",
     "lint": "eslint src/**/*.ts"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- delete unused Jest script from server package.json

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `cd server && npm run lint` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_b_68763e8b40e48322b4d8c1465154f637